### PR TITLE
Fix Labeled Icon View Background (#AI090A)

### DIFF
--- a/Portland Rose/Portland Rose/App/Controllers/Show User/PORShowUserController.m
+++ b/Portland Rose/Portland Rose/App/Controllers/Show User/PORShowUserController.m
@@ -82,7 +82,6 @@ static CGFloat const WIDTH_BORDER_PROFILE = 5;
   CGFloat inset;
   CGRect maskFrame;
   CGFloat contentScale;
-  CGFloat s;
   
   contentScale = [[UIScreen mainScreen] scale];
   cover = _viewImageCover;

--- a/Portland Rose/Portland Rose/App/Views/Labeled Icon/PORLabeledIconView.m
+++ b/Portland Rose/Portland Rose/App/Views/Labeled Icon/PORLabeledIconView.m
@@ -78,6 +78,9 @@ static NSString * const NAME_NIB = @"PORLabeledIconView";
   palette = [PORPalette sharedPalette];
   typeLibrary = [PORTypeLibrary sharedTypeLibrary];
   
+  [self setBackgroundColor:UIColor.clearColor];
+
+  
   // Set color
   if (!_color){
     _color = palette.colorText;

--- a/Portland Rose/Portland Rose/App/Views/Labeled Icon/PORLabeledIconView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Labeled Icon/PORLabeledIconView.xib
@@ -43,7 +43,7 @@
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="4SO-bG-gy2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Fib-dx-TDX"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4SO-bG-gy2" secondAttribute="trailing" id="V3X-k3-KvK"/>


### PR DESCRIPTION
This P.R. sets the labeled icon view's background color to `UIColor.clearColor`