### PR TITLE
Add Empty State View (#AJ010B)

### DIFF
--- a/Portland Rose/Portland Rose.xcodeproj/project.pbxproj
+++ b/Portland Rose/Portland Rose.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		5A200B442097939F008AB019 /* PORActionButtonDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A200B422097939F008AB019 /* PORActionButtonDemoViewController.m */; };
 		5A200B5320991A9D008AB019 /* PORIndexItinerariesFeedController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A200B5220991A9D008AB019 /* PORIndexItinerariesFeedController.m */; };
 		5A200B5720991C0B008AB019 /* PORIndexItinerariesPinnedController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A200B5620991C0B008AB019 /* PORIndexItinerariesPinnedController.m */; };
+		5A25865220A0DDBC00DB3C5F /* POREmptyStateView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */; };
+		5A25865420A0DDC600DB3C5F /* POREmptyStateView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */; };
 		5A445F0E20729AAE009497B0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A445F0D20729AAE009497B0 /* AppDelegate.m */; };
 		5A445F1420729AAE009497B0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A445F1220729AAE009497B0 /* Main.storyboard */; };
 		5A445F1620729AAF009497B0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5A445F1520729AAF009497B0 /* Assets.xcassets */; };
@@ -93,6 +95,9 @@
 		5A200B5220991A9D008AB019 /* PORIndexItinerariesFeedController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PORIndexItinerariesFeedController.m; sourceTree = "<group>"; };
 		5A200B5520991C0B008AB019 /* PORIndexItinerariesPinnedController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PORIndexItinerariesPinnedController.h; sourceTree = "<group>"; };
 		5A200B5620991C0B008AB019 /* PORIndexItinerariesPinnedController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PORIndexItinerariesPinnedController.m; sourceTree = "<group>"; };
+		5A25865020A0DDBC00DB3C5F /* POREmptyStateView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = POREmptyStateView.h; sourceTree = "<group>"; };
+		5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = POREmptyStateView.m; sourceTree = "<group>"; };
+		5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = POREmptyStateView.xib; sourceTree = "<group>"; };
 		5A445F0920729AAE009497B0 /* Portland Rose.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Portland Rose.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A445F0C20729AAE009497B0 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		5A445F0D20729AAE009497B0 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -301,6 +306,16 @@
 			path = "Index Itineraries Pinned";
 			sourceTree = "<group>";
 		};
+		5A25864F20A0DD9E00DB3C5F /* Empty State */ = {
+			isa = PBXGroup;
+			children = (
+				5A25865020A0DDBC00DB3C5F /* POREmptyStateView.h */,
+				5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */,
+				5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */,
+			);
+			path = "Empty State";
+			sourceTree = "<group>";
+		};
 		5A3A99FB2076A6FB00191EEF /* Action Button */ = {
 			isa = PBXGroup;
 			children = (
@@ -375,6 +390,7 @@
 			children = (
 				5A3A99FB2076A6FB00191EEF /* Action Button */,
 				5A0DCCCF208039EB000FCAAC /* Activity Cell */,
+				5A25864F20A0DD9E00DB3C5F /* Empty State */,
 				5AD02B08207D3FB800E48C9B /* Floating Action Button */,
 				5A7D9A322077FFB100EF6D73 /* Image Card */,
 				5AB7EAF62087F7B70087B7DB /* Image Carousel */,
@@ -813,6 +829,7 @@
 				5A445F1620729AAF009497B0 /* Assets.xcassets in Resources */,
 				5A445F1420729AAE009497B0 /* Main.storyboard in Resources */,
 				5A445F292072B790009497B0 /* Demo.storyboard in Resources */,
+				5A25865420A0DDC600DB3C5F /* POREmptyStateView.xib in Resources */,
 				5A0DCCD420803BC1000FCAAC /* PORActivityCellView.xib in Resources */,
 				5A0DCCDA208048B8000FCAAC /* PORLabeledIconView.xib in Resources */,
 				5A7D9A342077FFE300EF6D73 /* PORImageCardView.xib in Resources */,
@@ -831,6 +848,7 @@
 				5AFD5CA820890C6C009D2908 /* PORNavigationController.m in Sources */,
 				5A7B6B9F207FF6E700C99AA0 /* NSString+Random.m in Sources */,
 				5AB7EAF92087F7D10087B7DB /* PORImageCarouselView.m in Sources */,
+				5A25865220A0DDBC00DB3C5F /* POREmptyStateView.m in Sources */,
 				5A7B6B82207FB1A600C99AA0 /* PORItinerarySummaryDemoViewController.m in Sources */,
 				5A4F8B1520911C48006AE5E3 /* PORPalette.m in Sources */,
 				5A7B6B96207FEF6A00C99AA0 /* PORItinerary+Mocks.m in Sources */,

--- a/Portland Rose/Portland Rose.xcodeproj/project.pbxproj
+++ b/Portland Rose/Portland Rose.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5A200B5720991C0B008AB019 /* PORIndexItinerariesPinnedController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A200B5620991C0B008AB019 /* PORIndexItinerariesPinnedController.m */; };
 		5A25865220A0DDBC00DB3C5F /* POREmptyStateView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */; };
 		5A25865420A0DDC600DB3C5F /* POREmptyStateView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */; };
+		5A25865820A0F12300DB3C5F /* POREmptyStateDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A25865720A0F12300DB3C5F /* POREmptyStateDemoViewController.m */; };
 		5A445F0E20729AAE009497B0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A445F0D20729AAE009497B0 /* AppDelegate.m */; };
 		5A445F1420729AAE009497B0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A445F1220729AAE009497B0 /* Main.storyboard */; };
 		5A445F1620729AAF009497B0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5A445F1520729AAF009497B0 /* Assets.xcassets */; };
@@ -98,6 +99,8 @@
 		5A25865020A0DDBC00DB3C5F /* POREmptyStateView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = POREmptyStateView.h; sourceTree = "<group>"; };
 		5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = POREmptyStateView.m; sourceTree = "<group>"; };
 		5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = POREmptyStateView.xib; sourceTree = "<group>"; };
+		5A25865620A0F12300DB3C5F /* POREmptyStateDemoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = POREmptyStateDemoViewController.h; sourceTree = "<group>"; };
+		5A25865720A0F12300DB3C5F /* POREmptyStateDemoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = POREmptyStateDemoViewController.m; sourceTree = "<group>"; };
 		5A445F0920729AAE009497B0 /* Portland Rose.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Portland Rose.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A445F0C20729AAE009497B0 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		5A445F0D20729AAE009497B0 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -312,6 +315,15 @@
 				5A25865020A0DDBC00DB3C5F /* POREmptyStateView.h */,
 				5A25865120A0DDBC00DB3C5F /* POREmptyStateView.m */,
 				5A25865320A0DDC600DB3C5F /* POREmptyStateView.xib */,
+			);
+			path = "Empty State";
+			sourceTree = "<group>";
+		};
+		5A25865520A0F0DF00DB3C5F /* Empty State */ = {
+			isa = PBXGroup;
+			children = (
+				5A25865620A0F12300DB3C5F /* POREmptyStateDemoViewController.h */,
+				5A25865720A0F12300DB3C5F /* POREmptyStateDemoViewController.m */,
 			);
 			path = "Empty State";
 			sourceTree = "<group>";
@@ -712,6 +724,7 @@
 			children = (
 				5A200B412097939F008AB019 /* Action Button */,
 				5A0DCCCB208038D0000FCAAC /* Activity Cell */,
+				5A25865520A0F0DF00DB3C5F /* Empty State */,
 				5AC2A8F9207BEB36003B2AD5 /* Image Carousel */,
 				5A5933032087D14D003A1751 /* Itinerary Header Cell */,
 				5A7B6B83207FB1B600C99AA0 /* Itinerary Summary */,
@@ -880,6 +893,7 @@
 				5AA9491E20755A6000060FE8 /* PORTabBarView.m in Sources */,
 				5A5933012087D106003A1751 /* PORItineraryHeaderCellView.m in Sources */,
 				5AFD5CBA20893432009D2908 /* PORIndexItinerariesController.m in Sources */,
+				5A25865820A0F12300DB3C5F /* POREmptyStateDemoViewController.m in Sources */,
 				5A7B6B8C207FD88E00C99AA0 /* PORBadge.m in Sources */,
 				5A200B3120978C4B008AB019 /* PORRecord.m in Sources */,
 				5A200B5320991A9D008AB019 /* PORIndexItinerariesFeedController.m in Sources */,

--- a/Portland Rose/Portland Rose/App/Helpers/Palette/PORPalette.m
+++ b/Portland Rose/Portland Rose/App/Helpers/Palette/PORPalette.m
@@ -13,7 +13,7 @@ static NSString * const HEX_COMET = @"#59617E";
 static NSString * const HEX_FROLY = @"#F4727E";
 static NSString * const HEX_THULIAN_PINK = @"#EC6AA0";
 static NSString * const HEX_WHITE = @"#FFFFFF";
-static CGFloat const OPACITY_FAINT = 0.25;
+static CGFloat const OPACITY_FAINT = 0.12;
 
 @implementation PORPalette
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -15,8 +15,15 @@ IB_DESIGNABLE
 
 @interface POREmptyStateView : UIView
 
+/// Display a button?
+@property IBInspectable BOOL interactive;
+/// Text to display on the button (if any)
+@property IBInspectable NSString * textButton;
+/// Title text
 @property IBInspectable NSString * title;
+/// Subtitle text
 @property IBInspectable NSString * subtitle;
+
 
 @end
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -12,17 +12,26 @@
 #import <UIKit/UIKit.h>
 
 IB_DESIGNABLE
+@class POREmptyStateView;
+
+@protocol POREmptyStateViewDelegate
+
+- (void)didSelectEmptyStateView:(POREmptyStateView *)emptyStateView;
+
+@end
 
 @interface POREmptyStateView : UIView
 
 /// Display a button?
-@property IBInspectable BOOL actionable;
+@property (nonatomic) IBInspectable BOOL actionable;
+/// Delegate
+@property id<POREmptyStateViewDelegate> delegate;
 /// Title text
-@property IBInspectable NSString * headline;
+@property (nonatomic) IBInspectable NSString * headline;
 /// Subtitle text
-@property IBInspectable NSString * subhead;
+@property (nonatomic) IBInspectable NSString * subhead;
 /// Text to display on the button (if any)
-@property IBInspectable NSString * textButton;
+@property (nonatomic) IBInspectable NSString * textButton;
 
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -6,7 +6,10 @@
 //  Copyright © 2018 Useless Corporation. All rights reserved.
 //
 
+#import "PORPalette.h"
+#import "PORTypeLibrary.h"
 #import <UIKit/UIKit.h>
+
 IB_DESIGNABLE
 
 @interface POREmptyStateView : UIView

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -16,13 +16,13 @@ IB_DESIGNABLE
 @interface POREmptyStateView : UIView
 
 /// Display a button?
-@property IBInspectable BOOL interactive;
+@property IBInspectable BOOL actionable;
+/// Title text
+@property IBInspectable NSString * headline;
+/// Subtitle text
+@property IBInspectable NSString * subhead;
 /// Text to display on the button (if any)
 @property IBInspectable NSString * textButton;
-/// Title text
-@property IBInspectable NSString * title;
-/// Subtitle text
-@property IBInspectable NSString * subtitle;
 
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -1,0 +1,13 @@
+//
+//  POREmptyStateView.h
+//  Portland Rose
+//
+//  Created by Hunter Ford on 07/05/2018.
+//  Copyright © 2018 Useless Corporation. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface POREmptyStateView : UIView
+
+@end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -14,6 +14,9 @@ IB_DESIGNABLE
 
 @interface POREmptyStateView : UIView
 
+@property IBInspectable NSString * title;
+@property IBInspectable NSString * subtitle;
+
 @end
 
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -15,3 +15,9 @@ IB_DESIGNABLE
 @interface POREmptyStateView : UIView
 
 @end
+
+
+
+
+
+

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Useless Corporation. All rights reserved.
 //
 
+#import "PORActionButtonView.h"
 #import "PORPalette.h"
 #import "PORTypeLibrary.h"
 #import <UIKit/UIKit.h>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+IB_DESIGNABLE
 
 @interface POREmptyStateView : UIView
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -42,6 +42,11 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   return self;
 }
 
+- (void)layoutSubviews{
+  [self refresh];
+  [super layoutSubviews];
+}
+
 #pragma mark - helpers
 
 - (void)loadNib{
@@ -69,6 +74,11 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   // Set label colors
   [self.viewLabelHeadline setTextColor:palette.colorText];
   [self.viewLabelSubhead setTextColor:palette.colorText];
+}
+
+- (void)refresh{
+  [self.viewLabelHeadline setText:self.title];
+  [self.viewLabelSubhead setText:self.subtitle];
 }
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -15,6 +15,10 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
 
 /// Main view
 @property (strong, nonatomic) IBOutlet UIView *view;
+/// Headline view
+@property (weak, nonatomic) IBOutlet UILabel *viewLabelHeadline;
+/// Subheader view
+@property (weak, nonatomic) IBOutlet UILabel *viewLabelSubhead;
 
 @end
 
@@ -56,8 +60,15 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   
   // Set background
   [self setBackgroundColor:UIColor.clearColor];
-  [self.view setBackgroundColor: palette.colorDivider];
+  [self.view setBackgroundColor:palette.colorDivider];
   
+  // Set label fonts
+  [self.viewLabelHeadline setFont:typeLibrary.fontSubtitle];
+  [self.viewLabelSubhead setFont:typeLibrary.fontHeadline];
+  
+  // Set label colors
+  [self.viewLabelHeadline setTextColor:palette.colorText];
+  [self.viewLabelSubhead setTextColor:palette.colorText];
 }
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -44,10 +44,34 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   return self;
 }
 
-- (void)layoutSubviews{
+- (void)drawRect:(CGRect)rect{
   [self refresh];
-  [super layoutSubviews];
+  [super drawRect:rect];
 }
+
+
+#pragma mark - setters
+
+- (void)setActionable:(BOOL)actionable{
+  _actionable = actionable;
+  [self setNeedsDisplay];
+}
+
+- (void)setHeadline:(NSString *)headline{
+  _headline = headline;
+  [self setNeedsDisplay];
+}
+
+- (void)setSubhead:(NSString *)subhead{
+  _subhead = subhead;
+  [self setNeedsDisplay];
+}
+
+- (void)setTextButton:(NSString *)textButton{
+  _textButton = textButton;
+  [self setNeedsDisplay];
+}
+
 
 #pragma mark - helpers
 
@@ -95,5 +119,14 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   [self.viewLabelHeadline setText:self.headline];
   [self.viewLabelSubhead setText:self.subhead];
 }
+
+#pragma mark - events
+
+- (IBAction)didTapActionButton:(id)sender {
+  if (self.delegate){
+    [self.delegate didSelectEmptyStateView:self];
+  }
+}
+
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -1,0 +1,21 @@
+//
+//  POREmptyStateView.m
+//  Portland Rose
+//
+//  Created by Hunter Ford on 07/05/2018.
+//  Copyright © 2018 Useless Corporation. All rights reserved.
+//
+
+#import "POREmptyStateView.h"
+
+@implementation POREmptyStateView
+
+/*
+// Only override drawRect: if you perform custom drawing.
+// An empty implementation adversely affects performance during animation.
+- (void)drawRect:(CGRect)rect {
+    // Drawing code
+}
+*/
+
+@end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -76,9 +76,22 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   // Set label colors
   [self.viewLabelHeadline setTextColor:palette.colorText];
   [self.viewLabelSubhead setTextColor:palette.colorText];
+  
+  // Set default properties
+  self.interactive = NO;
+  self.subtitle = self.viewLabelSubhead.text;
+  self.textButton = self.viewButtonAction.text;
+  self.title = self.viewLabelHeadline.text;
 }
 
 - (void)refresh{
+  // Configure button visibility
+  [self.viewButtonAction setHidden:!self.interactive];
+  
+  // Configure button text
+  [self.viewButtonAction setText:self.textButton];
+  
+  // Configure label text
   [self.viewLabelHeadline setText:self.title];
   [self.viewLabelSubhead setText:self.subtitle];
 }

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -78,22 +78,22 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
   [self.viewLabelSubhead setTextColor:palette.colorText];
   
   // Set default properties
-  self.interactive = NO;
-  self.subtitle = self.viewLabelSubhead.text;
+  self.actionable = NO;
+  self.subhead = self.viewLabelSubhead.text;
   self.textButton = self.viewButtonAction.text;
-  self.title = self.viewLabelHeadline.text;
+  self.headline = self.viewLabelHeadline.text;
 }
 
 - (void)refresh{
   // Configure button visibility
-  [self.viewButtonAction setHidden:!self.interactive];
+  [self.viewButtonAction setHidden:!self.actionable];
   
   // Configure button text
   [self.viewButtonAction setText:self.textButton];
   
   // Configure label text
-  [self.viewLabelHeadline setText:self.title];
-  [self.viewLabelSubhead setText:self.subtitle];
+  [self.viewLabelHeadline setText:self.headline];
+  [self.viewLabelSubhead setText:self.subhead];
 }
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -8,14 +8,47 @@
 
 #import "POREmptyStateView.h"
 
+/// Nib filename
+static NSString * const NAME_NIB = @"POREmptyStateView";
+
+@interface POREmptyStateView()
+
+/// Main view
+@property (strong, nonatomic) IBOutlet UIView *view;
+
+@end
+
 @implementation POREmptyStateView
 
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
+#pragma mark - lifecycle
+
+- (instancetype) initWithCoder:(NSCoder *)aDecoder{
+  self = [super initWithCoder:aDecoder];
+  if (self){
+    [self loadNib];
+  }
+  return self;
 }
-*/
+
+- (instancetype) initWithFrame:(CGRect)frame{
+  self = [super initWithFrame:frame];
+  if (self){
+    [self loadNib];
+  }
+  return self;
+}
+
+#pragma mark - helpers
+
+- (void)loadNib{
+  [[NSBundle bundleForClass:self.class] loadNibNamed:NAME_NIB owner:self options:nil];
+  [self addSubview:_view];
+  [_view setFrame: self.bounds];
+  [self nibDidLoad];
+}
+
+- (void)nibDidLoad{
+  
+}
 
 @end

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -48,6 +48,15 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
 }
 
 - (void)nibDidLoad{
+  PORPalette * palette;
+  PORTypeLibrary * typeLibrary;
+  
+  palette = [PORPalette sharedPalette];
+  typeLibrary = [PORTypeLibrary sharedTypeLibrary];
+  
+  // Set background
+  [self setBackgroundColor:UIColor.clearColor];
+  [self.view setBackgroundColor: palette.colorDivider];
   
 }
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.m
@@ -19,6 +19,8 @@ static NSString * const NAME_NIB = @"POREmptyStateView";
 @property (weak, nonatomic) IBOutlet UILabel *viewLabelHeadline;
 /// Subheader view
 @property (weak, nonatomic) IBOutlet UILabel *viewLabelSubhead;
+/// Action button view (displayed if the user can interact with this empty state).
+@property (weak, nonatomic) IBOutlet PORActionButtonView *viewButtonAction;
 
 @end
 

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -1,18 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="POREmptyStateView">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="i9u-fW-eg8"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="558"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" red="0.12941176469999999" green="0.82745098039999998" blue="0.67450980390000004" alpha="1" colorSpace="calibratedRGB"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="1" y="32"/>
         </view>
     </objects>
 </document>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -26,7 +26,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="Mlh-0p-vAo">
                     <rect key="frame" x="40" y="187" width="295" height="184"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello, Puffins!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello, Puffins!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
                             <rect key="frame" x="94.5" y="0.0" width="106.5" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -13,6 +13,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="POREmptyStateView">
             <connections>
                 <outlet property="view" destination="iN0-l3-epB" id="i9u-fW-eg8"/>
+                <outlet property="viewButtonAction" destination="i9J-fz-jNH" id="SxB-nt-3Z7"/>
                 <outlet property="viewLabelHeadline" destination="wqd-ZW-Lfc" id="S5o-I5-9CW"/>
                 <outlet property="viewLabelSubhead" destination="6wL-1N-DTZ" id="hUj-Ss-oIn"/>
             </connections>
@@ -23,20 +24,28 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="Mlh-0p-vAo">
-                    <rect key="frame" x="40" y="247.5" width="295" height="63"/>
+                    <rect key="frame" x="40" y="187" width="295" height="184"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
-                            <rect key="frame" x="126.5" y="0.0" width="42" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello, Puffins!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
+                            <rect key="frame" x="94.5" y="0.0" width="106.5" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6wL-1N-DTZ">
-                            <rect key="frame" x="126.5" y="42.5" width="42" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6wL-1N-DTZ">
+                            <rect key="frame" x="1.5" y="42.5" width="292.5" height="81.5"/>
+                            <string key="text">Puffins rule — it's a scientific fact.  Much like the speed of light, the awesomeness of puffins is a universal constant that nothing may exceed.</string>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i9J-fz-jNH" customClass="PORActionButtonView">
+                            <rect key="frame" x="96" y="146" width="103" height="38"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="text" value="Try Again"/>
+                            </userDefinedRuntimeAttributes>
+                        </view>
                     </subviews>
                 </stackView>
             </subviews>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -13,13 +13,38 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="POREmptyStateView">
             <connections>
                 <outlet property="view" destination="iN0-l3-epB" id="i9u-fW-eg8"/>
+                <outlet property="viewLabelHeadline" destination="wqd-ZW-Lfc" id="S5o-I5-9CW"/>
+                <outlet property="viewLabelSubhead" destination="6wL-1N-DTZ" id="hUj-Ss-oIn"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="558"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mlh-0p-vAo">
+                    <rect key="frame" x="166.5" y="248.5" width="42" height="61"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
+                            <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6wL-1N-DTZ">
+                            <rect key="frame" x="0.0" y="40.5" width="42" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
             <color key="backgroundColor" red="0.12941176469999999" green="0.82745098039999998" blue="0.67450980390000004" alpha="1" colorSpace="calibratedRGB"/>
+            <constraints>
+                <constraint firstItem="Mlh-0p-vAo" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Eas-a5-JYm"/>
+                <constraint firstItem="Mlh-0p-vAo" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="YTx-Yh-8eD"/>
+            </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="1" y="32"/>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -22,17 +22,17 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="558"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mlh-0p-vAo">
-                    <rect key="frame" x="166.5" y="248.5" width="42" height="61"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="Mlh-0p-vAo">
+                    <rect key="frame" x="40" y="247.5" width="295" height="63"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
-                            <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-ZW-Lfc">
+                            <rect key="frame" x="126.5" y="0.0" width="42" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6wL-1N-DTZ">
-                            <rect key="frame" x="0.0" y="40.5" width="42" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6wL-1N-DTZ">
+                            <rect key="frame" x="126.5" y="42.5" width="42" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -44,6 +44,7 @@
             <constraints>
                 <constraint firstItem="Mlh-0p-vAo" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Eas-a5-JYm"/>
                 <constraint firstItem="Mlh-0p-vAo" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="YTx-Yh-8eD"/>
+                <constraint firstItem="Mlh-0p-vAo" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" constant="-80" id="pZB-3a-yKr"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -45,6 +45,9 @@
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="text" value="I Agree"/>
                             </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="didTapActionButton:" destination="-1" eventType="touchUpInside" id="Yo3-5a-l7T"/>
+                            </connections>
                         </view>
                     </subviews>
                 </stackView>

--- a/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
+++ b/Portland Rose/Portland Rose/App/Views/Empty State/POREmptyStateView.xib
@@ -40,10 +40,10 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i9J-fz-jNH" customClass="PORActionButtonView">
-                            <rect key="frame" x="96" y="146" width="103" height="38"/>
+                            <rect key="frame" x="102.5" y="146" width="90" height="38"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="text" value="Try Again"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="text" value="I Agree"/>
                             </userDefinedRuntimeAttributes>
                         </view>
                     </subviews>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -519,8 +519,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="Hello, Puffins!"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="subtitle" value="Puffins are the best. No, seriously. They are like the best things ever. Period. Full stop."/>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="interactive" value="YES"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -518,6 +518,10 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gu4-Fl-xwc" customClass="POREmptyStateView">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="Hello, Puffins!"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="subtitle" value="Puffins are the best."/>
+                                </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -520,7 +520,7 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="title" value="Hello, Puffins!"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="subtitle" value="Puffins are the best."/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="subtitle" value="Puffins are the best. No, seriously. They are like the best things ever. Period. Full stop."/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -57,6 +57,7 @@
                         <segue destination="iXV-9q-s6Z" kind="show" identifier="FromDemosToActivityCellViewDemo" id="30Y-t0-9YZ"/>
                         <segue destination="zm8-pe-owX" kind="show" identifier="FromDemosToItineraryHeaderCellViewDemo" id="9hh-ac-4BY"/>
                         <segue destination="N7l-ce-Eb4" kind="show" identifier="FromDemosToRecordBookDemo" id="Auy-jY-UFt"/>
+                        <segue destination="o4R-0n-ykr" kind="show" identifier="FromDemosToEmptyStateViewDemo" id="ZR2-Av-Kqc"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VMO-4V-ueg" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -505,6 +506,21 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6vB-8f-WXp" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3489" y="75"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="3MO-HI-1ue">
+            <objects>
+                <viewController id="o4R-0n-ykr" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="dYw-2x-v9z">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="KVr-fq-oLp"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yeW-33-H0R" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4159" y="75"/>
         </scene>
     </scenes>
     <resources>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -514,7 +514,19 @@
                     <view key="view" contentMode="scaleToFill" id="dYw-2x-v9z">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gu4-Fl-xwc" customClass="POREmptyStateView">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="KVr-fq-oLp" firstAttribute="bottom" secondItem="Gu4-Fl-xwc" secondAttribute="bottom" id="5jc-R7-yPs"/>
+                            <constraint firstItem="KVr-fq-oLp" firstAttribute="trailing" secondItem="Gu4-Fl-xwc" secondAttribute="trailing" id="EsY-c7-NHS"/>
+                            <constraint firstItem="Gu4-Fl-xwc" firstAttribute="leading" secondItem="KVr-fq-oLp" secondAttribute="leading" id="XZK-qk-Pup"/>
+                            <constraint firstItem="Gu4-Fl-xwc" firstAttribute="top" secondItem="KVr-fq-oLp" secondAttribute="top" id="hB0-yi-BVV"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="KVr-fq-oLp"/>
                     </view>
                 </viewController>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -519,7 +519,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="interactive" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="actionable" value="YES"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>

--- a/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
+++ b/Portland Rose/Portland Rose/Demo/Base.lproj/Demo.storyboard
@@ -507,10 +507,10 @@
             </objects>
             <point key="canvasLocation" x="3489" y="75"/>
         </scene>
-        <!--View Controller-->
+        <!--Empty State Demo View Controller-->
         <scene sceneID="3MO-HI-1ue">
             <objects>
-                <viewController id="o4R-0n-ykr" sceneMemberID="viewController">
+                <viewController id="o4R-0n-ykr" customClass="POREmptyStateDemoViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dYw-2x-v9z">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -532,6 +532,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="KVr-fq-oLp"/>
                     </view>
+                    <connections>
+                        <outlet property="viewEmptyState" destination="Gu4-Fl-xwc" id="Yif-hF-9s3"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yeW-33-H0R" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Portland Rose/Portland Rose/Demo/Demo Controllers/PORDemosViewController.m
+++ b/Portland Rose/Portland Rose/Demo/Demo Controllers/PORDemosViewController.m
@@ -9,7 +9,7 @@
 #import "PORDemosViewController.h"
 
 /// Comma-seperated list of demo views. IMPORTANT: These names must correspond to a valid segue identifier with the convention `"FromDemosTo<NAME_OF_DEMO>"`. For example, if `"Puffins Demo"` is part of the `NAMES_DEMO` list, this view controller will assume that there is a segue with the identifier `"FromDemosToPuffinsDemo"`.
-static NSString * const NAMES_DEMO = @"Action Button View Demo,Activity Cell View Demo,Floating Action Button View Demo,Image Card View Demo,Image Carousel View Demo,Itinerary Header Cell View Demo,Itinerary Summary View Demo,Palette Demo,Record Book Demo,Tab Bar Controller Demo,Type Library Demo";
+static NSString * const NAMES_DEMO = @"Action Button View Demo,Activity Cell View Demo,Empty State View Demo,Floating Action Button View Demo,Image Card View Demo,Image Carousel View Demo,Itinerary Header Cell View Demo,Itinerary Summary View Demo,Palette Demo,Record Book Demo,Tab Bar Controller Demo,Type Library Demo";
 /// Reuse identifier for the demo table cell
 static NSString * const REUSE_IDENTIFIER_CELL_DEMO = @"DemoCell";
 /// Demos View Controller scene title

--- a/Portland Rose/Portland Rose/Demo/Demo Controllers/View Demos/Empty State/POREmptyStateDemoViewController.h
+++ b/Portland Rose/Portland Rose/Demo/Demo Controllers/View Demos/Empty State/POREmptyStateDemoViewController.h
@@ -1,0 +1,13 @@
+//
+//  POREmptyStateDemoViewController.h
+//  Portland Rose
+//
+//  Created by Hunter Ford on 07/05/2018.
+//  Copyright © 2018 Useless Corporation. All rights reserved.
+//
+#import "POREmptyStateView.h"
+#import <UIKit/UIKit.h>
+
+@interface POREmptyStateDemoViewController : UIViewController <POREmptyStateViewDelegate>
+
+@end

--- a/Portland Rose/Portland Rose/Demo/Demo Controllers/View Demos/Empty State/POREmptyStateDemoViewController.m
+++ b/Portland Rose/Portland Rose/Demo/Demo Controllers/View Demos/Empty State/POREmptyStateDemoViewController.m
@@ -1,0 +1,35 @@
+//
+//  POREmptyStateDemoViewController.m
+//  Portland Rose
+//
+//  Created by Hunter Ford on 07/05/2018.
+//  Copyright © 2018 Useless Corporation. All rights reserved.
+//
+
+#import "POREmptyStateDemoViewController.h"
+
+@interface POREmptyStateDemoViewController ()
+
+@property (weak, nonatomic) IBOutlet POREmptyStateView *viewEmptyState;
+
+@end
+
+@implementation POREmptyStateDemoViewController
+
+#pragma mark - lifecycle
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [self.viewEmptyState setDelegate:self];
+}
+
+#pragma mark - <POREmptyStateViewDelegate>
+
+- (void)didSelectEmptyStateView:(POREmptyStateView *)emptyStateView{
+  [self.viewEmptyState setActionable:NO];
+  [self.viewEmptyState setSubhead:nil];
+  [self.viewEmptyState setHeadline:@"Good"];
+}
+
+
+@end

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -392,6 +392,44 @@ interface builder.
 }
 ```
 
+### Empty State View
+
+`POREmptyStateView` renders an empty state view.  The most common
+applications for an empty state are:
+
+* First use (when a collection is empty by default)
+* When a user clears a collection
+* Error populating collection items
+
+`POREmptyStateView` displays a short header / subheader to describe why
+the user is seeing the view.  If the user can perform an action (e.g.
+"Try Again" on an empty state view displayed on a network error), a
+`POREmptyStateView` can be configured to display an action button and
+respond to taps on it.
+
+#### Usage
+
+**Properties**
+
+* **Actionable** — `actionable` indicates whether or not the user can
+  perform an action.  If `actionable` is `YES`, a button will be
+  added to the view. 
+* **Button Text** — `textButton` determines the text to display on the
+  view's action button.
+* **Header** — `header` is the header text to display.
+* **Subheader** — `subhead` is the subheader text to display.
+
+**Handling Events**
+
+To handle user taps on the action button, implement the
+`POREmptyStateViewDelegate` protocol:
+
+```objective-c
+- (void)didSelectEmptyStateView:(POREmptyStateView *)emptyStateView{
+  NSLog(@"Hello, Puffins!");
+}
+```
+
 ### Floating Action Button View
 
 `PORFloatingActionButtonView` renders a button with an icon image and a 


### PR DESCRIPTION
This P.R. adds an empty state view to show to users when: (1) content is empty by default; (2) content was removed by the user; or (3) content could not be displayed due to an error.

<img width="1280" alt="screen shot 2018-05-07 at 17 29 53" src="https://user-images.githubusercontent.com/9771612/39726204-5a1df67a-521c-11e8-87e7-77e05672ec0a.png">
